### PR TITLE
add qstring, std::wstring summary provider

### DIFF
--- a/lldb/.lldbinit
+++ b/lldb/.lldbinit
@@ -1,5 +1,8 @@
 command script import ~/settings/lldb/lldb_wchar_t_summary_provider.py
 command script import ~/settings/lldb/lldb_qstring_summary_provider.py
+command script import ~/settings/lldb/lldb_std_wstring_summary_provider.py
 type summary add -F lldb_wchar_t_summary_provider.utf16 "wchar_t *"
 command regex pw 's/(.+)/print (wchar_t*) %1/'
 type summary add -F lldb_qstring_summary_provider.qstring_summary "QString"
+type summary add -F lldb_std_wstring_summary_provider.std_wstring_summary "hncstd::wstring"
+type summary add -F lldb_std_wstring_summary_provider.std_wstring_summary "std::wstring"

--- a/lldb/.lldbinit
+++ b/lldb/.lldbinit
@@ -1,3 +1,5 @@
 command script import ~/settings/lldb/lldb_wchar_t_summary_provider.py
+command script import ~/settings/lldb/lldb_qstring_summary_provider.py
 type summary add -F lldb_wchar_t_summary_provider.utf16 "wchar_t *"
 command regex pw 's/(.+)/print (wchar_t*) %1/'
+type summary add -F lldb_qstring_summary_provider.qstring_summary "QString"

--- a/lldb/lldb_qstring_summary_provider.py
+++ b/lldb/lldb_qstring_summary_provider.py
@@ -1,0 +1,37 @@
+# https://stackoverflow.com/questions/25370142/can-lldb-data-formatters-call-methods
+
+def make_string_from_pointer_with_offset(F,OFFS,L):
+    strval = 'u"'
+    try:
+        data_array = F.GetPointeeData(0, L).uint16
+        for X in range(OFFS, L):
+            V = data_array[X]
+            if V == 0:
+                break
+            strval += unichr(V)
+    except:
+        pass
+    strval = strval + '"'
+    return strval.encode('utf-8')
+
+
+#qt5
+def qstring_summary(value, unused):
+    try:
+        d = value.GetChildMemberWithName('d')
+        #have to divide by 2 (size of unsigned short = 2)
+        offset = d.GetChildMemberWithName('offset').GetValueAsUnsigned() / 2
+        size = get_max_size(value)
+        return make_string_from_pointer_with_offset(d, offset, size)
+    except:
+        print '?????????????????????????'
+        return value
+
+def get_max_size(value):
+    _max_size_ = None
+    try:
+        debugger = value.GetTarget().GetDebugger()
+        _max_size_ = int(lldb.SBDebugger.GetInternalVariableValue('target.max-string-summary-length', debugger.GetInstanceName()).GetStringAtIndex(0))
+    except:
+        _max_size_ = 512
+    return _max_size_

--- a/lldb/lldb_std_wstring_summary_provider.py
+++ b/lldb/lldb_std_wstring_summary_provider.py
@@ -1,0 +1,13 @@
+import ~/settings/lldb/lldb_wchar_t_summary_provider.py
+
+def std_wstring_summary(value, unused):
+    try:
+        d = value.GetChildMemberWithName('__r_')
+            .GetChildAtIndex(0)
+            .GetChildMemberWithName('__value_')
+            .GetChildMemberWithName('__l')
+            .GetChildMemberWithName('__data_')
+        return lldb_wchar_t_summary_provider.utf16(d)
+    except:
+        print '?????????????????????????'
+        return value


### PR DESCRIPTION
* for printing QString

* solution url
https://stackoverflow.com/questions/25370142/can-lldb-data-formatters-call-methods